### PR TITLE
@stargaze/api -> @public-awesome/stargaze-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ yarn start
 
 The app should be running on http://localhost:3000.
 
-> Pro tip 💡: everytime you modify the `@stargaze/api` package, be sure to run again `yarn build:api`, to let the other packages in the monorepo be aware of your latest changes. You can also add to `--watch` flag on this command to build on file change.
+> Pro tip 💡: everytime you modify the `@public-awesome/stargaze-api` package, be sure to run again `yarn build:api`, to let the other packages in the monorepo be aware of your latest changes. You can also add to `--watch` flag on this command to build on file change.
 
 ## Packages
 
 Regen-JS consists of many smaller npm packages within the [@stargaze namespace](https://www.npmjs.com/org/regennetwork), a so called monorepo. Here is the list of all packages.
 
-| Package                                     | Description                                         | Latest                                                                                                                |
-| ------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| [@stargaze/api](packages/api)           | A client library interacting with the Regen Ledger. | [![npm version](https://img.shields.io/npm/v/@stargaze/api.svg)](https://www.npmjs.com/package/@stargaze/api) |
-| [@stargaze/demo-app](packages/demo-app) | A demo React app using `@stargaze/api`.         | Not published on npm.                                                                                                 |
+| Package                                      | Description                                            | Latest                                                                                                                                      |
+| -------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@public-awesome/stargaze-api](packages/api) | A client library interacting with the Regen Ledger.    | [![npm version](https://img.shields.io/npm/v/@public-awesome/stargaze-api.svg)](https://www.npmjs.com/package/@public-awesome/stargaze-api) |
+| [@stargaze/demo-app](packages/demo-app)      | A demo React app using `@public-awesome/stargaze-api`. | Not published on npm.                                                                                                                       |
 
 ## Build the packages from source
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
 	"license": "Apache-2.0",
 	"private": true,
 	"repository": "https://github.com/public-awesome/stargaze-js",
-	"workspaces": [
-		"packages/*"
-	],
+	"workspaces": ["packages/*"],
 	"scripts": {
-		"build:api": "yarn workspace @stargaze/api build",
+		"build:api": "yarn workspace @public-awesome/stargaze-api build",
 		"build": "lerna run build --stream",
 		"format": "yarn lint --fix",
 		"lint": "tsc --noEmit && eslint --ext js,ts,tsx .",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,4 +1,4 @@
-# `@stargaze/api`
+# `@public-awesome/stargaze-api`
 
 A client library for the Regen Ledger.
 
@@ -7,7 +7,7 @@ A client library for the Regen Ledger.
 The library exposes one main TypeScript class: the `StargazeApi` class. Import it like this in your code:
 
 ```ts
-import { StargazeApi } from '@stargaze/api';
+import { StargazeApi } from '@public-awesome/stargaze-api';
 
 // Create a new instance of the StargazeApi class.
 const api = new StargazeApi({

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@stargaze/api",
+	"name": "@public-awesome/stargaze-api",
 	"version": "0.1.1",
 	"author": "shanev@gmail.com",
 	"description": "A client library for the Stargaze blockchain",

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -2,12 +2,12 @@
 	"name": "@stargaze/demo-app",
 	"version": "0.1.0",
 	"author": "admin@regen.network",
-	"description": "Demo web application using @stargaze/api",
+	"description": "Demo web application using @public-awesome/stargaze-api",
 	"license": "Apache-2.0",
 	"private": true,
 	"repository": "https://github.com/public-awesome/stargaze-js",
 	"dependencies": {
-		"@stargaze/api": "^0.1.0",
+		"@public-awesome/stargaze-api": "^0.1.0",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
 		"@testing-library/user-event": "^12.1.10",
@@ -28,11 +28,7 @@
 		"eject": "react-scripts eject"
 	},
 	"browserslist": {
-		"production": [
-			">0.2%",
-			"not dead",
-			"not op_mini all"
-		],
+		"production": [">0.2%", "not dead", "not op_mini all"],
 		"development": [
 			"last 1 chrome version",
 			"last 1 firefox version",

--- a/packages/demo-app/src/App.tsx
+++ b/packages/demo-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { StargazeApi } from '@stargaze/api';
+import { StargazeApi } from '@public-awesome/stargaze-api';
 import { useEffect, useState } from 'react';
 import * as React from 'react';
 
@@ -33,7 +33,8 @@ export function App(): React.ReactElement {
 	return (
 		<div>
 			<h1>
-				Regen Network Demo App using <code>@stargaze/api</code>
+				Regen Network Demo App using{' '}
+				<code>@public-awesome/stargaze-api</code>
 			</h1>
 
 			{api ? (

--- a/packages/demo-app/src/MyBalance.tsx
+++ b/packages/demo-app/src/MyBalance.tsx
@@ -1,6 +1,6 @@
-import type { StargazeApi } from '@stargaze/api';
-import type { QueryAllBalancesResponse } from '@stargaze/api/lib/generated/cosmos/bank/v1beta1/query';
-import { QueryClientImpl } from '@stargaze/api/lib/generated/cosmos/bank/v1beta1/query';
+import type { StargazeApi } from '@public-awesome/stargaze-api';
+import type { QueryAllBalancesResponse } from '@public-awesome/stargaze-api/lib/generated/cosmos/bank/v1beta1/query';
+import { QueryClientImpl } from '@public-awesome/stargaze-api/lib/generated/cosmos/bank/v1beta1/query';
 import React, { useEffect, useState } from 'react';
 
 interface MyBalanceProps {


### PR DESCRIPTION
Our npm org changed to `@public-awesome`. This pr updates the package name to reflect that.

https://docs.npmjs.com/creating-and-publishing-an-organization-scoped-package